### PR TITLE
Fix caching issues with nested mapcats and prepopulated caches

### DIFF
--- a/src/urania/core.cljc
+++ b/src/urania/core.cljc
@@ -75,7 +75,7 @@
   (-inject [_ env]
     (let [next (clojure.core/map (partial inject-into env) values)]
       (if (every? -done? next)
-        (let [result (apply f (clojure.core/map :value next))]
+        (let [result (inject-into env (apply f (clojure.core/map :value next)))]
           ;; xxx: refactor to avoid dummy leaves creation
           (if (satisfies? DataSource result)
             (Map. identity [result])
@@ -228,7 +228,7 @@
             responses (clojure.core/map (partial fetch-resource opts) requests-by-type)]
         (prom/branch (prom/all responses)
                      (fn [results]
-                       (let [next-cache (into cache results)
+                       (let [next-cache (merge-with merge cache (into {} results))
                              next-opts (assoc opts :cache next-cache)]
                          (interpret-ast ast-node next-opts success! error!)))
                      error!)))))


### PR DESCRIPTION
On one hand prepopulated caches are not merged properly (see `core_spec.clj:130` in the PR for a test that reproduces this), and on the other it seems that FlatMaps don't try to `inject-into` deep enough, so that with nested mapcats the cache is never used (`core_spec.clj:182` and `core_spec.clj:190` for tests reproducing the bug).

Let me know if there are any concerns about style, etc, or if I've misunderstood / missed some bits.

Thank you a lot @dialelo for the library by the way, at my current client I've been rewriting lots of messy, hand-crafted logic with it and I was fleshing out these minor bugs while testing to put it in production :) If / when it gets merged, I'd really appreciate a patch release.