### PR TITLE
Allow extending protocols via metadata

### DIFF
--- a/src/urania/core.cljc
+++ b/src/urania/core.cljc
@@ -7,10 +7,12 @@
   (:refer-clojure :exclude (map mapcat run!)))
 
 (defprotocol IExecutor
+  :extend-via-metadata true
   "A policy for executing tasks."
   (-execute [ex task] "Perform a task."))
 
 (defprotocol DataSource
+  :extend-via-metadata true
   "A remote data source."
   (-identity [this]
     "Return an identifier for this data source.
@@ -19,12 +21,14 @@
     "Fetch this data source "))
 
 (defprotocol BatchedSource
+  :extend-via-metadata true
   "A remote data source that can be fetched in batches."
   (-fetch-multi [this resources env]
     "Fetch this and other data sources in a single batch.
     The returned promise must be a map from the data source identities to their results."))
 
 (defprotocol Cache
+  :extend-via-metadata true
   "A lookup for previously fetched responses"
   (-get [this resource-name cache-id not-found])
   (-into [this responses-by-resource-name]))
@@ -34,11 +38,13 @@
 (declare inject-into)
 
 (defprotocol AST
+  :extend-via-metadata true
   (-children [this])
   (-inject [this env])
   (-done? [this]))
 
 (defprotocol ComposedAST
+  :extend-via-metadata true
   (-compose-ast [this f]))
 
 (defrecord Done [value]

--- a/test/urania/core_spec.cljc
+++ b/test/urania/core_spec.cljc
@@ -1,5 +1,5 @@
 (ns urania.core-spec
-  (:require [clojure.test :refer [deftest is] :refer-macros [async]]
+  (:require [clojure.test :refer [deftest is testing] :refer-macros [async]]
             [promesa.core :as prom]
             [urania.core :as u]))
 
@@ -339,3 +339,16 @@
                  (u/collect [(Environment. 42) (Environment. 99)])
                  identity
                  {:env :the-environment})))
+
+(deftest satisfies?-test
+  (testing "reified type"
+    (let [example (reify u/IExecutor
+                    (-execute [_ task]
+                      (task)))]
+      (is (true?  (u/satisfies? u/IExecutor  example)))
+      (is (false? (u/satisfies? u/DataSource example)))))
+
+  (testing "metadata"
+    (let [example (with-meta {} {`u/-execute (fn [_ task] (task))})]
+      (is (true?  (u/satisfies? u/IExecutor  example)))
+      (is (false? (u/satisfies? u/DataSource example))))))


### PR DESCRIPTION
## Brief

This change allows the protocols to be used with https://clojure.org/reference/protocols#_extend_via_metadata.

## Rational

In our team it's very common to use metadata to extend protocols instead of their reify/deftype counterparts. We want to prevent usage of macros which wrap `defrecord` (e.g. `def-fetcher` in superlifter) to prevent issues with cloverage and reloading workflow (which is what we do with https://github.com/nedap/utils.modular/#nedaputilsmodularapiimplement, hence metadata protocols)

---

Note that `clojure.core/satisfies?` can't deal with metadata-extended protocol implementations. hence the fix in f94c4ff. 

The implementation is copied from https://github.com/nedap/speced.def/blob/33a494d79281cd096b3dad48cd76e4674a62fc70/src/nedap/speced/def.cljc#L133.  There's also exhaustive tests for `satisfies?` present https://github.com/nedap/speced.def/blob/master/test/unit/nedap/speced/api/satisfies.clj, i copied a bare example into this repo as well. `speced.def` is used extensively and are running in production for more than a year now.