### PR TITLE
Reject promise when datasources throw exceptions

### DIFF
--- a/src/urania/core.cljc
+++ b/src/urania/core.cljc
@@ -170,6 +170,7 @@
   (prom/create
    (fn [resolve reject]
      (-execute executor #(-> (try (-fetch muse env)
+                                  ;; fast fail if datasource throws accidentally
                                   (catch #?(:clj Exception :cljs :default) e
                                     (prom/rejected e)))
                              (prom/then resolve)
@@ -180,6 +181,7 @@
   (prom/create
    (fn [resolve reject]
      (-execute executor #(-> (try (-fetch-multi muse muses env)
+                                  ;; fast fail if datasource throws accidentally
                                   (catch #?(:clj Exception :cljs :default) e
                                     (prom/rejected e)))
                              (prom/then resolve)

--- a/src/urania/core.cljc
+++ b/src/urania/core.cljc
@@ -170,8 +170,8 @@
   (prom/create
    (fn [resolve reject]
      (-execute executor #(-> (try (-fetch muse env)
-                                  (catch Exception ex
-                                    (prom/rejected ex)))
+                                  (catch #?(:clj Exception :cljs :default) e
+                                    (prom/rejected e)))
                              (prom/then resolve)
                              (prom/catch reject))))))
 
@@ -180,8 +180,8 @@
   (prom/create
    (fn [resolve reject]
      (-execute executor #(-> (try (-fetch-multi muse muses env)
-                                  (catch Exception ex
-                                    (prom/rejected ex)))
+                                  (catch #?(:clj Exception :cljs :default) e
+                                    (prom/rejected e)))
                              (prom/then resolve)
                              (prom/catch reject))))))
 

--- a/src/urania/core.cljc
+++ b/src/urania/core.cljc
@@ -169,7 +169,9 @@
   [{:keys [executor env]} muse]
   (prom/create
    (fn [resolve reject]
-     (-execute executor #(-> (-fetch muse env)
+     (-execute executor #(-> (try (-fetch muse env)
+                                  (catch Exception ex
+                                    (prom/rejected ex)))
                              (prom/then resolve)
                              (prom/catch reject))))))
 
@@ -177,7 +179,9 @@
   [{:keys [executor env]} muse muses]
   (prom/create
    (fn [resolve reject]
-     (-execute executor #(-> (-fetch-multi muse muses env)
+     (-execute executor #(-> (try (-fetch-multi muse muses env)
+                                  (catch Exception ex
+                                    (prom/rejected ex)))
                              (prom/then resolve)
                              (prom/catch reject))))))
 


### PR DESCRIPTION
As described in https://github.com/funcool/urania/issues/16

If you have a datasource that throws (instead of returning a rejected promise!), you'll get a hanging `u/execute!` call.

Here we catch these exceptions early, reject the entire promise (as if the datasource returned a rejected promise itself).