### PR TITLE
Preserve thread bindings when running fetchers

### DIFF
--- a/src/urania/core.cljc
+++ b/src/urania/core.cljc
@@ -198,23 +198,25 @@
   [{:keys [executor env]} muse]
   (prom/create
    (fn [resolve reject]
-     (-execute executor #(-> (try (-fetch muse env)
-                                  ;; fast fail if datasource throws accidentally
-                                  (catch #?(:clj Exception :cljs :default) e
-                                    (prom/rejected e)))
-                             (prom/then resolve)
-                             (prom/catch reject))))))
+     (-execute executor (bound-fn []
+                          (-> (try (-fetch muse env)
+                                   ;; fast fail if datasource throws accidentally
+                                   (catch #?(:clj Exception :cljs :default) e
+                                     (prom/rejected e)))
+                              (prom/then resolve)
+                              (prom/catch reject)))))))
 
 (defn- run-fetch-multi
   [{:keys [executor env]} muse muses]
   (prom/create
    (fn [resolve reject]
-     (-execute executor #(-> (try (-fetch-multi muse muses env)
-                                  ;; fast fail if datasource throws accidentally
-                                  (catch #?(:clj Exception :cljs :default) e
-                                    (prom/rejected e)))
-                             (prom/then resolve)
-                             (prom/catch reject))))))
+     (-execute executor (bound-fn []
+                          (-> (try (-fetch-multi muse muses env)
+                                   ;; fast fail if datasource throws accidentally
+                                   (catch #?(:clj Exception :cljs :default) e
+                                     (prom/rejected e)))
+                              (prom/then resolve)
+                              (prom/catch reject)))))))
 
 (defn- fetch-many-caching
   [opts sources]

--- a/test/urania/core_spec_test.cljc
+++ b/test/urania/core_spec_test.cljc
@@ -28,6 +28,13 @@
   (-identity [_] seed)
   (-fetch [_ _] (throw (ex-info "Uncaught" {:seed seed}))))
 
+(def ^:dynamic dynamic-value 1)
+
+(deftype Dynamic []
+  u/DataSource
+  (-identity [_] dynamic-value)
+  (-fetch [_ _] (prom/resolved dynamic-value)))
+
 (defn- mk-pair [seed] (Pair. seed))
 
 (defn- sum-pair [[a b]] (+ a b))
@@ -415,3 +422,10 @@
                  (u/collect [(Environment. 42) (Environment. 99)])
                  identity
                  {:env :the-environment})))
+
+#?(:clj
+   (deftest thread-bindings-test
+     (assert-ast [1] (u/collect [(Dynamic.)]))
+
+     (binding [dynamic-value 2]
+       (assert-ast [2] (u/collect [(Dynamic.)])))))


### PR DESCRIPTION
When urania runs a fetcher, either from [run-fetch](https://github.com/funcool/urania/blob/4043efef7e7e280a40417f38250168e99a3b5fec/src/urania/core.cljc#L197-L206) or [run-fetch-multi](https://github.com/funcool/urania/blob/4043efef7e7e280a40417f38250168e99a3b5fec/src/urania/core.cljc#L208-L217), it submits a function to an executor so it runs on a different thread.

However, it should wrap the function with [bound-fn](https://clojuredocs.org/clojure.core/bound-fn) to preserve any bindings that might exist on the current thread. Not doing so could result in unexpected results if the function relies on dynamic values shared via thread bindings, like a DB connection or logging configuration.

Relevant code: https://github.com/funcool/urania/blob/4043efef7e7e280a40417f38250168e99a3b5fec/src/urania/core.cljc#L197-L206